### PR TITLE
feat: add --yes flag to skip confirmation and auto-skip on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ split-cli delete traffic-type tt_user123 -w ws_abc123
 - `-w, --workspace <id>`: Workspace ID (required for most commands)
 - `--cascade`: Delete all child resources (default: false)
 - `--dry-run`: Preview what would be deleted without actually deleting
+- `--non-interactive`: Skip confirmation prompts (for CI/scripted usage)
+- `--ignore-errors`: Continue on errors and exit 0 (best-effort cleanup)
 - `--debug`: Enable debug logging with detailed API request/response information
 
 ### Examples
@@ -222,9 +224,9 @@ All resource deletions will **fail** if the resource has any child resources or 
 ## Safety Features
 
 1. **Explicit Cascade Requirement**: You must explicitly use `--cascade` to delete resources with children
-2. **Interactive Confirmation**: Shows a tree of all resources to be deleted and requires confirmation
+2. **Interactive Confirmation**: Shows a tree of all resources to be deleted and requires confirmation (bypass with `--non-interactive`)
 3. **Dry-Run Mode**: Test deletions without making changes
-4. **Error Handling**: Interactive prompts to retry, skip, or abort on errors
+4. **Error Handling**: Interactive prompts to retry, skip, or abort on errors (auto-skips with `--ignore-errors`)
 5. **Sanitized Logging**: API keys are never shown in debug logs
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ split-cli delete traffic-type tt_user123 -w ws_abc123
 - `-w, --workspace <id>`: Workspace ID (required for most commands)
 - `--cascade`: Delete all child resources (default: false)
 - `--dry-run`: Preview what would be deleted without actually deleting
-- `--non-interactive`: Skip confirmation prompts (for CI/scripted usage)
-- `--ignore-errors`: Continue on errors and exit 0 (best-effort cleanup)
+- `--yes`: Skip confirmation prompts (for CI/scripted usage)
+- `--skip-on-error`: Continue on errors and exit 0 (best-effort cleanup)
 - `--debug`: Enable debug logging with detailed API request/response information
 
 ### Examples
@@ -224,9 +224,9 @@ All resource deletions will **fail** if the resource has any child resources or 
 ## Safety Features
 
 1. **Explicit Cascade Requirement**: You must explicitly use `--cascade` to delete resources with children
-2. **Interactive Confirmation**: Shows a tree of all resources to be deleted and requires confirmation (bypass with `--non-interactive`)
+2. **Interactive Confirmation**: Shows a tree of all resources to be deleted and requires confirmation (bypass with `--yes`)
 3. **Dry-Run Mode**: Test deletions without making changes
-4. **Error Handling**: Interactive prompts to retry, skip, or abort on errors (auto-skips with `--ignore-errors`)
+4. **Error Handling**: Interactive prompts to retry, skip, or abort on errors (auto-skips with `--skip-on-error`)
 5. **Sanitized Logging**: API keys are never shown in debug logs
 
 ## Architecture

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ interface CommonOptions {
   cascade: boolean;
   dryRun: boolean;
   debug: boolean;
+  nonInteractive: boolean;
+  ignoreErrors: boolean;
 }
 
 /**
@@ -52,6 +54,8 @@ async function executeDelete(
     // Prepare delete options
     const deleteOptions: DeleteOptions = {
       cascade: options.cascade,
+      nonInteractive: options.nonInteractive,
+      ignoreErrors: options.ignoreErrors,
     };
 
     // Execute the deletion
@@ -62,7 +66,7 @@ async function executeDelete(
       process.exit(0);
     } else {
       console.error(`\n❌ Failed to delete ${type} '${name}'`);
-      process.exit(1);
+      process.exit(options.ignoreErrors ? 0 : 1);
     }
   } catch (error) {
     if (error instanceof Error) {
@@ -70,7 +74,7 @@ async function executeDelete(
     } else {
       console.error(`\n❌ Unknown error occurred`);
     }
-    process.exit(1);
+    process.exit(options.ignoreErrors ? 0 : 1);
   }
 }
 
@@ -88,6 +92,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete all child resources (flags, segments, environments, traffic types)')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (workspaceId: string, options: Omit<CommonOptions, 'workspace'>) => {
@@ -97,6 +103,8 @@ deleteCmd
       workspace: workspaceId,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });
@@ -110,6 +118,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete all split definitions in this environment')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (nameOrId: string, options: CommonOptions) => {
@@ -119,6 +129,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });
@@ -132,6 +144,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete all definitions across all environments')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -141,6 +155,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });
@@ -154,6 +170,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete segment including all keys')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -163,6 +181,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });
@@ -176,6 +196,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete large segment including all keys')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -185,6 +207,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });
@@ -198,6 +222,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete rule-based segment including all rules')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -207,6 +233,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });
@@ -219,6 +247,8 @@ deleteCmd
   .option('--api-key <key>', 'Split.io API key (or use SPLIT_API_KEY env var)')
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (trafficTypeId: string, options: CommonOptions) => {
@@ -228,6 +258,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: false, // Traffic types don't cascade
       dryRun: options.dryRun || false,
+      nonInteractive: options.nonInteractive || false,
+      ignoreErrors: options.ignoreErrors || false,
       debug: options.debug || false,
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ interface CommonOptions {
   cascade: boolean;
   dryRun: boolean;
   debug: boolean;
-  nonInteractive: boolean;
-  ignoreErrors: boolean;
+  yes: boolean;
+  skipOnError: boolean;
 }
 
 /**
@@ -54,8 +54,8 @@ async function executeDelete(
     // Prepare delete options
     const deleteOptions: DeleteOptions = {
       cascade: options.cascade,
-      nonInteractive: options.nonInteractive,
-      ignoreErrors: options.ignoreErrors,
+      yes: options.yes,
+      skipOnError: options.skipOnError,
     };
 
     // Execute the deletion
@@ -66,7 +66,7 @@ async function executeDelete(
       process.exit(0);
     } else {
       console.error(`\n❌ Failed to delete ${type} '${name}'`);
-      process.exit(options.ignoreErrors ? 0 : 1);
+      process.exit(options.skipOnError ? 0 : 1);
     }
   } catch (error) {
     if (error instanceof Error) {
@@ -74,7 +74,7 @@ async function executeDelete(
     } else {
       console.error(`\n❌ Unknown error occurred`);
     }
-    process.exit(options.ignoreErrors ? 0 : 1);
+    process.exit(options.skipOnError ? 0 : 1);
   }
 }
 
@@ -92,8 +92,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete all child resources (flags, segments, environments, traffic types)')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (workspaceId: string, options: Omit<CommonOptions, 'workspace'>) => {
@@ -103,8 +103,8 @@ deleteCmd
       workspace: workspaceId,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });
@@ -118,8 +118,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete all split definitions in this environment')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (nameOrId: string, options: CommonOptions) => {
@@ -129,8 +129,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });
@@ -144,8 +144,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete all definitions across all environments')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -155,8 +155,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });
@@ -170,8 +170,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete segment including all keys')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -181,8 +181,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });
@@ -196,8 +196,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete large segment including all keys')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -207,8 +207,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });
@@ -222,8 +222,8 @@ deleteCmd
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--cascade', 'Delete rule-based segment including all rules')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (name: string, options: CommonOptions) => {
@@ -233,8 +233,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: options.cascade || false,
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });
@@ -247,8 +247,8 @@ deleteCmd
   .option('--api-key <key>', 'Split.io API key (or use SPLIT_API_KEY env var)')
   .option('--base-url <url>', 'Split.io API base URL (default: https://api.split.io/internal/api/v2)')
   .option('--dry-run', 'Show what would be deleted without actually deleting')
-  .option('--non-interactive', 'Skip confirmation prompts (for CI/scripted usage)')
-  .option('--ignore-errors', 'Continue on errors and exit 0 (best-effort cleanup)')
+  .option('--yes', 'Skip confirmation prompts (for CI/scripted usage)')
+  .option('--skip-on-error', 'Continue on errors and exit 0 (best-effort cleanup)')
   .option('--debug', 'Enable debug logging')
   .showHelpAfterError()
   .action(async (trafficTypeId: string, options: CommonOptions) => {
@@ -258,8 +258,8 @@ deleteCmd
       workspace: options.workspace,
       cascade: false, // Traffic types don't cascade
       dryRun: options.dryRun || false,
-      nonInteractive: options.nonInteractive || false,
-      ignoreErrors: options.ignoreErrors || false,
+      yes: options.yes || false,
+      skipOnError: options.skipOnError || false,
       debug: options.debug || false,
     });
   });

--- a/src/services/DeleteService.ts
+++ b/src/services/DeleteService.ts
@@ -41,15 +41,19 @@ export class DeleteService {
     }
 
     // Show the deletion tree and get confirmation
-    const confirmed = await this.confirmDeletion(tree, options.cascade);
-
-    if (!confirmed) {
-      console.log('Deletion cancelled.');
-      return false;
+    if (options.nonInteractive) {
+      const message = this.formatDeletionTree(tree, options.cascade);
+      console.log(message);
+    } else {
+      const confirmed = await this.confirmDeletion(tree, options.cascade);
+      if (!confirmed) {
+        console.log('Deletion cancelled.');
+        return false;
+      }
     }
 
     // Execute the deletion
-    return await this.executeDeletion(tree);
+    return await this.executeDeletion(tree, options.ignoreErrors);
   }
 
   /**
@@ -519,18 +523,27 @@ export class DeleteService {
   /**
    * Execute deletion of the tree (children first, parent last)
    */
-  private async executeDeletion(node: DeleteTreeNode): Promise<boolean> {
+  private async executeDeletion(node: DeleteTreeNode, skipOnError: boolean = false): Promise<boolean> {
     // Delete children first (post-order traversal)
     for (const child of node.children) {
-      const success = await this.executeDeletion(child);
+      const success = await this.executeDeletion(child, skipOnError);
       if (!success) {
+        if (skipOnError) {
+          console.warn(`⚠️  Skipping failed child: ${child.type} '${child.name}'`);
+          continue;
+        }
         console.error(`Failed to delete child: ${child.type} '${child.name}'`);
         return false;
       }
     }
 
     // Then delete the node itself
-    return await this.deleteNode(node);
+    const success = await this.deleteNode(node);
+    if (!success && skipOnError) {
+      console.warn(`⚠️  Skipping failed node: ${node.type} '${node.name}'`);
+      return true;
+    }
+    return success;
   }
 
   /**

--- a/src/services/DeleteService.ts
+++ b/src/services/DeleteService.ts
@@ -4,6 +4,7 @@
 
 import { SplitApi } from '../api/SplitApi';
 import { confirmDeletion } from '../utils/stdin';
+import { DeletionReport } from './DeletionReport';
 import {
   ResourceType,
   DeleteTreeNode,
@@ -53,7 +54,10 @@ export class DeleteService {
     }
 
     // Execute the deletion
-    return await this.executeDeletion(tree, options.ignoreErrors);
+    const report = new DeletionReport();
+    await this.executeDeletion(tree, !!options.ignoreErrors, report);
+    report.print();
+    return !report.hadFailures;
   }
 
   /**
@@ -523,27 +527,22 @@ export class DeleteService {
   /**
    * Execute deletion of the tree (children first, parent last)
    */
-  private async executeDeletion(node: DeleteTreeNode, skipOnError: boolean = false): Promise<boolean> {
-    // Delete children first (post-order traversal)
+  private async executeDeletion(node: DeleteTreeNode, skipOnError: boolean, report: DeletionReport): Promise<boolean> {
     for (const child of node.children) {
-      const success = await this.executeDeletion(child, skipOnError);
-      if (!success) {
-        if (skipOnError) {
-          console.warn(`⚠️  Skipping failed child: ${child.type} '${child.name}'`);
-          continue;
-        }
-        console.error(`Failed to delete child: ${child.type} '${child.name}'`);
+      const success = await this.executeDeletion(child, skipOnError, report);
+      if (!success && !skipOnError) {
         return false;
       }
     }
 
-    // Then delete the node itself
     const success = await this.deleteNode(node);
-    if (!success && skipOnError) {
-      console.warn(`⚠️  Skipping failed node: ${node.type} '${node.name}'`);
-      return true;
+    report.record(node.type, node.name, success, success ? undefined : 'deletion failed');
+
+    if (!success && !skipOnError) {
+      return false;
     }
-    return success;
+
+    return true;
   }
 
   /**

--- a/src/services/DeleteService.ts
+++ b/src/services/DeleteService.ts
@@ -42,7 +42,7 @@ export class DeleteService {
     }
 
     // Show the deletion tree and get confirmation
-    if (options.nonInteractive) {
+    if (options.yes) {
       const message = this.formatDeletionTree(tree, options.cascade);
       console.log(message);
     } else {
@@ -55,7 +55,7 @@ export class DeleteService {
 
     // Execute the deletion
     const report = new DeletionReport();
-    await this.executeDeletion(tree, !!options.ignoreErrors, report);
+    await this.executeDeletion(tree, !!options.skipOnError, report);
     report.print();
     return !report.hadFailures;
   }

--- a/src/services/DeletionReport.ts
+++ b/src/services/DeletionReport.ts
@@ -1,0 +1,45 @@
+import { ResourceType } from '../types/split';
+
+interface DeletionResult {
+  type: ResourceType;
+  name: string;
+  success: boolean;
+  error?: string | undefined;
+}
+
+export class DeletionReport {
+  private readonly results: DeletionResult[] = [];
+
+  record(type: ResourceType, name: string, success: boolean, error?: string): void {
+    this.results.push({ type, name, success, error });
+  }
+
+  get succeeded(): DeletionResult[] {
+    return this.results.filter(r => r.success);
+  }
+
+  get failed(): DeletionResult[] {
+    return this.results.filter(r => !r.success);
+  }
+
+  get hadFailures(): boolean {
+    return this.failed.length > 0;
+  }
+
+  print(): void {
+    const s = this.succeeded.length;
+    const f = this.failed.length;
+
+    if (f === 0) {
+      console.log(`\nAll ${s} resource${s === 1 ? '' : 's'} deleted successfully.`);
+      return;
+    }
+
+    console.log(`\nDeletion summary: ${s} succeeded, ${f} failed.`);
+    console.log('  Failed:');
+    for (const result of this.failed) {
+      const detail = result.error ? ` (${result.error})` : '';
+      console.log(`    ${result.type} '${result.name}'${detail}`);
+    }
+  }
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,4 +11,6 @@ export interface CliConfig {
 export interface DeleteOptions {
   cascade: boolean;
   force?: boolean;
+  nonInteractive?: boolean;
+  ignoreErrors?: boolean;
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,6 +11,6 @@ export interface CliConfig {
 export interface DeleteOptions {
   cascade: boolean;
   force?: boolean;
-  nonInteractive?: boolean;
-  ignoreErrors?: boolean;
+  yes?: boolean;
+  skipOnError?: boolean;
 }


### PR DESCRIPTION
Enables non-interactive usage (CI, automated cleanup scripts) by:
- Skipping the "Proceed with deletion?" confirmation prompt
- Automatically skipping failed resources instead of prompting for abort/skip/retry. Aborting by default is arguably a better option, but with more verbose logging (later), skipping should be safe.